### PR TITLE
fix for SelectListAction filter whenever action completed with errors

### DIFF
--- a/src/MvcExtensions.FluentMetadata/ActionFilter/SelectListActionAttribute.cs
+++ b/src/MvcExtensions.FluentMetadata/ActionFilter/SelectListActionAttribute.cs
@@ -38,8 +38,12 @@ namespace MvcExtensions
         /// <param name="context">The filter context.</param>
         public void OnActionExecuted(ActionExecutedContext context)
         {
-            var result = (ViewResultBase)context.Result;
-            CopyViewDataProperties(context.ParentActionViewContext.ViewData, result.ViewData);
+            //copy view data only if action was completed successfuly
+            if (context.Exception == null)
+            {
+                var result = (ViewResultBase)context.Result;
+                CopyViewDataProperties(context.ParentActionViewContext.ViewData, result.ViewData);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
...whenever currently executing action throws exception (because in this case context.Result is EmptyResult and it's not instance of ViewResultBase class)
